### PR TITLE
Add stack traces to response for 500s

### DIFF
--- a/src/main/scala/geotrellis/analysis/Main.scala
+++ b/src/main/scala/geotrellis/analysis/Main.scala
@@ -6,6 +6,8 @@ import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.server.Directives
 
+import geotrellis.analysis.exception._
+
 object AkkaSystem {
   implicit val system = ActorSystem()
   implicit val materializer = ActorMaterializer()
@@ -19,6 +21,8 @@ object AkkaSystem {
 object Main extends App with Config with AkkaSystem.LoggerExecutor {
   import AkkaSystem._
   import Directives._
+
+  implicit def stackTraceHandler = ExceptionHandling.stackTraceHandler
 
   Http().bindAndHandle(Routes(), httpConfig.interface, httpConfig.port)
 }

--- a/src/main/scala/geotrellis/analysis/exception/Exceptions.scala
+++ b/src/main/scala/geotrellis/analysis/exception/Exceptions.scala
@@ -1,0 +1,17 @@
+package geotrellis.analysis.exception
+
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.Directives._
+
+import java.io._
+
+object ExceptionHandling {
+  def stackTraceHandler = ExceptionHandler {
+    case e: Exception =>
+      val sw = new StringWriter()
+      val pw = new PrintWriter(sw)
+      e.printStackTrace(pw)
+      complete(sw.toString())
+  }
+}
+


### PR DESCRIPTION
This should make debugging a bit easier on a cluster. 500s are responded to with stack traces
