### PR TITLE
Fix: CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ EXPOSE 7070
 
 COPY target/scala-2.11/comparative-analysis-bastion-assembly-0.0.1.jar /opt/app/comparative-analysis-bastion-assembly-0.0.1.jar
 
-CMD sleep 200 && java -jar /opt/app/comparative-analysis-bastion-assembly-0.0.1.jar
-
+CMD [ "java", "-jar", "/opt/app/comparative-analysis-bastion-assembly-0.0.1.jar" ]


### PR DESCRIPTION
Avoid using shell syntax of CMD to preserve ENV
pushed to quay and it appears to fix the problem on ECS.

https://docs.docker.com/engine/reference/builder/#/cmd
